### PR TITLE
Fix Virt-customizing setting machine-id

### DIFF
--- a/ubuntu-template-create.sh
+++ b/ubuntu-template-create.sh
@@ -119,7 +119,8 @@ virt-customize -a "$IMAGE_NAME" \
     --run-command 'rm -rf /var/lib/apt/lists/*' \
     --run-command 'dd if=/dev/zero of=/EMPTY bs=1M || true' \
     --run-command 'rm -f /EMPTY' \
-    --run-command 'cloud-init clean'
+    --run-command 'cloud-init clean' \
+    --truncate '/etc/machine-id'
 
 
 # Create the VM template


### PR DESCRIPTION
Fixing virt-customize creating a machine-id to the Template on use. The command "cloud-init clean" should had clean this from the documentation I read, but on my testing clones from a Template have the same machine-id after boot. 
I found the solution for fixing that using only virt-customize by Truncating the machine-id file. It guaranties a new machine id generation on first boot. Tested on ubuntu-24.04-server-cloudimg-amd64.img